### PR TITLE
Adjust new lines after ends of divs

### DIFF
--- a/lib/Compiler/Method/Table.php
+++ b/lib/Compiler/Method/Table.php
@@ -59,9 +59,9 @@ class Table implements CompilerInterface
             $contents .= $this->compileMethod($method);
         }
 
-        $contents .= self::PARAGRAPH;
-        $contents .= '</div>';
         $contents .= self::NEWLINE;
+        $contents .= '</div>';
+        $contents .= self::PARAGRAPH;
 
         return $contents;
     }

--- a/lib/Compiler/Property/Table.php
+++ b/lib/Compiler/Property/Table.php
@@ -60,9 +60,9 @@ class Table implements CompilerInterface
             );
         }
 
-        $contents .= self::PARAGRAPH;
-        $contents .= '</div>';
         $contents .= self::NEWLINE;
+        $contents .= '</div>';
+        $contents .= self::PARAGRAPH;
 
         return $contents;
     }


### PR DESCRIPTION
The current way tables end created markup like ...

```html
</div>
### Next Heading
```

This prevented 11ty from converting the `### Next Heading` into `<h3>Next Heading</h3>`. This tweak swaps around the `self::PARAGRAPH` and `self::NEWLINE` so the markup is 11ty friendly! Now it looks like ...

```html
</div>

### Next Heading
```
