### PR TITLE
fix: Fix a bug when hook reference returned empty

### DIFF
--- a/lib/Compiler/HookReference.php
+++ b/lib/Compiler/HookReference.php
@@ -68,7 +68,7 @@ class HookReference implements CompilerInterface
                 }
 
                 $this->lastDocBlock = $docBlock;
-            } elseif (T_STRING === $type && $this->isHook($contents)) {
+            } elseif (!empty(trim($contents)) && $this->isHook($contents)) {
                 $hookName = $this->findNextHookName($tokens, $key);
 
                 if ($this->isValidHook($hookName)) {
@@ -208,6 +208,9 @@ class HookReference implements CompilerInterface
             'do_action_ref_array',
             'do_action_deprecated',
         );
+
+        // Remove any leading backslashes.
+        $name = ltrim($name, '\\');
 
         return in_array($name, $functions);
     }


### PR DESCRIPTION
Ticket:

- #5

This PR fixes two bugs that lead to the hook reference being empty when using PHP 8 while generating the docs. The first bug was a check that didn’t work anymore.

The second bug was because we prefixed hooks with `\` (`\apply_filters` and `\do_action`) in the Timber codebase. So these hooks were not recognized anymore. I added a check to trim any `\` to fix that.