### PR TITLE
Add table-responsive div around tables

### DIFF
--- a/lib/Compiler/Method/Table.php
+++ b/lib/Compiler/Method/Table.php
@@ -49,7 +49,7 @@ class Table implements CompilerInterface
             return ($a->getName() < $b->getName()) ? -1 : 1;
         });
 
-        $contents = '<div class="table-methods">';
+        $contents = '<div class="table-methods table-responsive">';
         $contents .= self::PARAGRAPH;
 
         $contents .= '| Name | Return Type | Summary/Returns |' . self::NEWLINE;
@@ -84,7 +84,7 @@ class Table implements CompilerInterface
 
         $return = sprintf(
             '| <span class="method-name">[%1$s](#%2$s)</span> | '
-            . '<span class="method-type">%3$s</span> | ',
+                . '<span class="method-type">%3$s</span> | ',
             $name,
             $this->sanitizeAnchor($method->getName()),
             $this->sanitizeTypeList($method->getReturnType())
@@ -93,13 +93,13 @@ class Table implements CompilerInterface
         $return .= '<span class="method-description">';
 
         if (!empty($method->getSummary())) {
-        	$return .= $this->sanitizeTextForTable($method->getSummary());
+            $return .= $this->sanitizeTextForTable($method->getSummary());
         }
 
         if (!empty($method->getReturnDescription())) {
-	        $return .= '<br><br><span class="method-return"><span class="method-return-label">Returns:</span> '
-               . $this->sanitizeTextForTable($method->getReturnDescription())
-               . '</span>';
+            $return .= '<br><br><span class="method-return"><span class="method-return-label">Returns:</span> '
+                . $this->sanitizeTextForTable($method->getReturnDescription())
+                . '</span>';
         }
 
         $return .= '</span> |';

--- a/lib/Compiler/Param/Table.php
+++ b/lib/Compiler/Param/Table.php
@@ -41,7 +41,7 @@ class Table implements CompilerInterface
         if (!is_array($this->params) || empty($this->params)) {
             return $contents;
         }
-
+        $contents = '<div class="table-responsive">';
         $contents .= '| Name | Type | Description |' . self::NEWLINE;
         $contents .= '| --- | --- | --- |' . self::NEWLINE;
 
@@ -70,6 +70,7 @@ class Table implements CompilerInterface
         }
 
         $contents .= self::NEWLINE;
+        $contents .= '</div>';
 
         return $contents;
     }

--- a/lib/Compiler/Property/Table.php
+++ b/lib/Compiler/Property/Table.php
@@ -43,7 +43,7 @@ class Table implements CompilerInterface
             return $contents;
         }
 
-        $contents .= '<div class="table-properties">';
+        $contents .= '<div class="table-properties table-responsive">';
         $contents .= self::PARAGRAPH;
 
         $contents .= '| Name | Type | Description |' . self::NEWLINE;
@@ -52,8 +52,8 @@ class Table implements CompilerInterface
         foreach ($this->properties as $param) {
             $contents .= sprintf(
                 '| <span class="property-name">$%1$s</span> | '
-                 . '<span class="property-type">%2$s</span> | '
-                 . '<span class="property-description">%3$s</span> |' . self::NEWLINE,
+                    . '<span class="property-type">%2$s</span> | '
+                    . '<span class="property-description">%3$s</span> |' . self::NEWLINE,
                 $param->getName(),
                 $this->sanitizeTypeList($param->getDocBlockType()),
                 $this->sanitizeTextForTable($param->getDescription())


### PR DESCRIPTION
To handle responsiveness of tables it would be great to add a uniform div tag around all tables with a specific classname.
We could then use the classname to handle responsive tables in the docs since the docs are now overflowing on mobile on reference pages.