### PR TITLE
fix: Fix for function generator not working because class is not defined

### DIFF
--- a/lib/Compiler/Method/Method.php
+++ b/lib/Compiler/Method/Method.php
@@ -89,13 +89,14 @@ class Method implements CompilerInterface
         // Return Tag
         $contents .= (new Return_($this->method))->compile();
 
-        if (!empty($this->class->getParentMethods())
+        if (
+            $this->class && !empty($this->class->getParentMethods())
             && in_array($this->method->reflection->getFqsen()->__toString(), array_keys($this->class->getParentMethods()))
-       ) {
+        ) {
             $contents .= self::NEWLINE;
             $contents .= '*This method is inherited from `' . $this->class->getParent() . '`.*';
             $contents .= self::PARAGRAPH;
-       }
+        }
 
         if ($this->method->hasParameters()) {
             $paramsTable = new Table($this->method->getParameters());


### PR DESCRIPTION
Function generator was not working anymore since the class property was not defined. Let's fix that!

Would be nice if we could add a function test as well, might look into that in the future.