### PR TITLE
feat: Add Hooked tag compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ The `@example` tag allows you add code examples to your DocBlocks, including fen
 function my_method( $param1 = 'value', $param2 = true ) {}
 ```
 
+#### @hooked
+
+The `@hooked` tag allows you to mark which internal functions are hooked to your action.
+
+```php
+/**
+ * Fires in the head element of the website
+ * 
+ * @hooked my_statistics_function - 10 (Outputs the statistics code, if enabled)
+ * @hooked my_analytics_function - 11 (Outputs the analytics meta tags, if enabled)
+ */
+do_action('my_custom_head');
+```
+
 #### Parameters that are arrays
 
 Teak supports [parameters that are arrays](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#1-1-parameters-that-are-arrays).

--- a/lib/Compiler/Hook.php
+++ b/lib/Compiler/Hook.php
@@ -6,6 +6,7 @@ use Teak\Compiler\Param\Table as ParamTable;
 use Teak\Compiler\Tag\Deprecated;
 use Teak\Compiler\Tag\Description;
 use Teak\Compiler\Tag\Example;
+use Teak\Compiler\Tag\Hooked;
 use Teak\Compiler\Tag\Link;
 use Teak\Compiler\Tag\See;
 use Teak\Compiler\Tag\Since;
@@ -54,6 +55,9 @@ class Hook implements CompilerInterface
 
         // Link tag
         $contents .= (new Link($this->docBlock))->compile();
+
+        // Hooked tag
+        $contents .= (new Hooked($this->docBlock))->compile();
 
         // Since tag
         $contents .= (new Since($this->docBlock))->compile();

--- a/lib/Compiler/Tag/Hooked.php
+++ b/lib/Compiler/Tag/Hooked.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Teak\Compiler\Tag;
+
+use Teak\Compiler\CompilerInterface;
+use Teak\Reflection\DocBlock;
+
+/**
+ * Class Link
+ */
+class Hooked implements CompilerInterface
+{
+   /**
+    * @var \phpDocumentor\Reflection\DocBlock\Tags\Link
+    */
+   protected $tags;
+
+   /**
+    * Link constructor.
+    *
+    * @param \phpDocumentor\Reflection\DocBlock $docBlock
+    */
+   public function __construct($docBlock)
+   {
+      $docBlock = new DocBlock($docBlock);
+      $this->tags = $docBlock->getTags('hooked');
+   }
+
+   /**
+    * Compile.
+    *
+    * @return string
+    */
+   public function compile()
+   {
+      $contents = '';
+
+      if (empty($this->tags)) {
+         return $contents;
+      }
+
+      $contents .= '**Hooked** ' . self::PARAGRAPH;
+      $contents .= '<div class="table-hooked table-responsive">';
+      $contents .= self::PARAGRAPH;
+      $contents .= '| Name | priority | Description |' . self::NEWLINE;
+      $contents .= '| --- | --- | --- |' . self::NEWLINE;
+      foreach ($this->tags as $tag) {
+
+         // hook name is everything before the first -
+         $hook_name = strstr($tag, '-', true);
+
+         // priority is everything between the first - and (
+         $hook_priority = substr($tag, strlen($hook_name) + 1, strpos($tag, '(') - strlen($hook_name) - 1);
+
+         // description is everything between ( and )
+         $hook_description = substr($tag, strpos($tag, '(') + 1, strrpos($tag, ')') - strpos($tag, '(') - 1);
+
+         $contents .= sprintf(
+            '| <span class="hook-name"><code>%1$s</code></span> | '
+               . '<span class="hook-priority">%2$s</span> | '
+               . '<span class="hook-description">%3$s</span> |' . self::NEWLINE,
+            $hook_name,
+            $hook_priority,
+            $hook_description
+         );
+      }
+      $contents .= self::PARAGRAPH;
+      $contents .= '</div>';
+      $contents .= self::PARAGRAPH;
+      return $contents;
+   }
+}

--- a/lib/Compiler/Tag/Hooked.php
+++ b/lib/Compiler/Tag/Hooked.php
@@ -45,6 +45,12 @@ class Hooked implements CompilerInterface
       $contents .= '| Name | Priority | Description |' . self::NEWLINE;
       $contents .= '| --- | --- | --- |' . self::NEWLINE;
       foreach ($this->tags as $tag) {
+         // if tags is empty
+
+         if (strlen(trim($tag)) == 0) {
+            continue;
+         }
+
          $parsed = $this->parseHookTag($tag);
 
          $contents .= sprintf(

--- a/lib/Compiler/Tag/Hooked.php
+++ b/lib/Compiler/Tag/Hooked.php
@@ -42,31 +42,56 @@ class Hooked implements CompilerInterface
       $contents .= '**Hooked** ' . self::PARAGRAPH;
       $contents .= '<div class="table-hooked table-responsive">';
       $contents .= self::PARAGRAPH;
-      $contents .= '| Name | priority | Description |' . self::NEWLINE;
+      $contents .= '| Name | Priority | Description |' . self::NEWLINE;
       $contents .= '| --- | --- | --- |' . self::NEWLINE;
       foreach ($this->tags as $tag) {
-
-         // hook name is everything before the first -
-         $hook_name = strstr($tag, '-', true);
-
-         // priority is everything between the first - and (
-         $hook_priority = substr($tag, strlen($hook_name) + 1, strpos($tag, '(') - strlen($hook_name) - 1);
-
-         // description is everything between ( and )
-         $hook_description = substr($tag, strpos($tag, '(') + 1, strrpos($tag, ')') - strpos($tag, '(') - 1);
+         $parsed = $this->parseHookTag($tag);
 
          $contents .= sprintf(
             '| <span class="hook-name"><code>%1$s</code></span> | '
                . '<span class="hook-priority">%2$s</span> | '
                . '<span class="hook-description">%3$s</span> |' . self::NEWLINE,
-            $hook_name,
-            $hook_priority,
-            $hook_description
+            $parsed['name'],
+            $parsed['priority'],
+            $parsed['description']
          );
       }
       $contents .= self::PARAGRAPH;
       $contents .= '</div>';
       $contents .= self::PARAGRAPH;
       return $contents;
+   }
+
+   /**
+    * Parse a hook tag to extract name, priority, and description.
+    *
+    * @param string $tag
+    * @return array
+    */
+   private function parseHookTag($tag)
+   {
+      // Extract description from parentheses
+      $description = 'No description provided';
+      if (preg_match('/\(([^)]+)\)/', $tag, $matches)) {
+         $description = $matches[1];
+         // Remove description from tag for further parsing
+         $tag = preg_replace('/\([^)]+\)/', '', $tag);
+      }
+
+      // Split by dash to get name and priority
+      $parts = explode('-', $tag, 2);
+      $name = trim($parts[0]);
+      $priority = isset($parts[1]) ? trim($parts[1]) : '10';
+
+      // Default priority if empty
+      if (empty($priority)) {
+         $priority = '10';
+      }
+
+      return [
+         'name' => $name,
+         'priority' => $priority,
+         'description' => $description
+      ];
    }
 }


### PR DESCRIPTION
The `@hooked` tag is widely used to mark which functions are hooked to a particular action. With this PR something like the following:

```php
/**
 * Fires in the head for custom meta tags.
 * 
 * @hooked my_function - 10 (Outputs the statistics code, if enabled)
 * @hooked my_other_function - 11 (Outputs the analytics meta tags, if enabled)
 */
do_action('my_action_name');

```

becomes:
## my_action_name

Fires in the head for custom meta tags.

**Hooked** 

<div class="table-hooked table-responsive">

| Name | Priority | Description |
| --- | --- | --- |
| <span class="hook-name"><code>my_function </code></span> | <span class="hook-priority">10</span> | <span class="hook-description">Outputs the statistics code, if enabled</span> |
| <span class="hook-name"><code>my_other_function</code></span> | <span class="hook-priority">11</span> | <span class="hook-description">Outputs the analytics meta tags, if enabled</span> |
</div>

I did some tests when no priority is provided (default back to 10) and with no description and a combination of these two. Empty `@hooked` tags are omitted.